### PR TITLE
One approach to solve the issue that I could think of

### DIFF
--- a/DynamicODataRouting/DynamicODataRouting/Controllers/CommonController.cs
+++ b/DynamicODataRouting/DynamicODataRouting/Controllers/CommonController.cs
@@ -21,21 +21,31 @@ namespace DynamicODataRouting.Controllers
             this.twoStorageProvider = twoStorageProvider;
         }
 
-        [EnableQuery]
-        public async Task<IActionResult> GetAsync()
+        public async Task<IActionResult> GetAsync(ODataQueryOptions<T> queryOptions)
         {
+            Response response = new Response();
+            response.Metadata = new List<string>()
+            {
+                "One",
+                "Two",
+            };
+
             if (typeof(T) == typeof(One))
             {
                 IQueryable<One> result = await oneStorageProvider.GetAllDataAsync();
-                return Ok(result);
+                response.Content = queryOptions.ApplyTo(result);
             }
             else if (typeof(T) == typeof(Two))
             {
                 IQueryable<Two> result = await twoStorageProvider.GetAllDataAsync();
-                return Ok(result);
+                response.Content = queryOptions.ApplyTo(result);
+            }
+            else
+            {
+                return BadRequest();
             }
 
-            return BadRequest();
+            return Ok(response);
         }
     }
 }

--- a/DynamicODataRouting/DynamicODataRouting/Models/Response.cs
+++ b/DynamicODataRouting/DynamicODataRouting/Models/Response.cs
@@ -1,0 +1,9 @@
+﻿namespace DynamicODataRouting.Models
+{
+    public class Response
+    {
+        public IQueryable Content { get; set; }
+
+        public ICollection<string> Metadata { get; set; }
+    }
+}


### PR DESCRIPTION
This solution here gets me closer to what I need but with this OData seems to think that this is no longer an OData response, so it gets rid of the "@odata.context" and other odata related response metadata. E.g., "@odata.count" is no longer included.

With this change, the following route:
/api/one?$filter=id eq 2&$select=id,name&$count=true

Gets me the following. Note how this no longer looks like an "odata" response:

```json
{
  "content": [
    {
      "Id": 2,
      "Name": "B"
    }
  ],
  "metadata": [
    "One",
    "Two"
  ]
}
```